### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semgrep.yaml
+++ b/.github/workflows/semgrep.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   semgrep:
     name: semgrep/ci
+    permissions:
+      contents: read
     runs-on: ubuntu-20.04
     env:
       SEMGREP_APP_TOKEN: ${{ secrets.SEMGREP_APP_TOKEN }}


### PR DESCRIPTION
Potential fix for [https://github.com/Maia-DAO/sdks/security/code-scanning/6](https://github.com/Maia-DAO/sdks/security/code-scanning/6)

To fix this issue, we need to explicitly define a `permissions:` block for the workflow or the specific job (`semgrep`) in `.github/workflows/semgrep.yaml`. The minimal starting point recommended is `contents: read`, which allows the workflow to read repository content but not write to it or perform other actions. Given the steps shown (checking out code and running Semgrep), this appears fully sufficient. You can add permissions either at the workflow root (applies to all jobs unless overridden) or under the specific job (applies only to that job). The best way in this situation is to add the following block under the `semgrep` job (just above `runs-on:`):

```yaml
permissions:
  contents: read
```

No additional methods, imports, or setup is necessary; just update the YAML.

Changes required:
- Edit `.github/workflows/semgrep.yaml`, insert the `permissions:` block under `semgrep:` before `runs-on:`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
