### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/semantic-release.yaml
+++ b/.github/workflows/semantic-release.yaml
@@ -9,6 +9,8 @@ on:
 jobs:
   release:
     name: Release
+    permissions:
+      contents: write
     environment:
       name: production
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/Maia-DAO/sdks/security/code-scanning/5](https://github.com/Maia-DAO/sdks/security/code-scanning/5)

To fix this problem, add a `permissions` block to the workflow (recommended at the job level if only one job needs these permissions, otherwise at the root level). Since the job publishes releases and might push tags/assets, the minimal required permission for semantic-release workflows is usually `contents: write` (read isn't enough for publishing releases), but it is advisable to be as restrictive as possible. If, for example, the workflow also creates release pull requests, you might also need `pull-requests: write`. For now, the best fix is to add `permissions: contents: write` under the job definition at line 11, ensuring the job only has the required permission.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
